### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,53 @@
-log4net.Azure
-=============
+#log4net.Azure
 
-log4net.Azure
+Transfer all your logs to the [Azure Table or Blob Storage](http://azure.microsoft.com/de-de/services/storage/) via Appender for [log4Net](https://logging.apache.org/log4net/)
+
+## Install
+Add To project via NuGet:  
+1. Right click on a project and click 'Manage NuGet Packages'.  
+2. Search for 'log4net.Appender.Azure' and click 'Install'.  
+
+## Configuration
+### Table Storage 
+Every log entry ist stored in a separate row.
+
+	<appender name="AzureTableAppender" type="log4net.Appender.AzureTableAppender, log4net.Appender.Azure">
+	   <param name="TableName" value="testLoggingTable"/>
+	   <!-- You can either specify a connection string or use the ConnectionStringName property instead -->
+	   <param name="ConnectionString" value="UseDevelopmentStorage=true"/>
+	   <!--<param name="ConnectionStringName" value="GlobalConfigurationString" />-->
+	   <!-- You can specify this to make each LogProperty as separate Column in TableStorage, 
+		Default: all Custom Properties were logged into one single field -->
+	   <param name="PropAsColumn" value="true" />
+	 </appender>
+	
+* <b>TableName:</b>
+  Name of the table in Table Storage
+* <b>ConnectionString:</b>
+  the full Azure Storage connection string
+* <b>ConnectionStringName:</b>
+  Name of a connection string specified under connectionString
+	
+### BlobStorage
+Every log Entry is stored as separate XML file.
+
+    <appender name="AzureBlobAppender" type="log4net.Appender.AzureBlobAppender, log4net.Appender.Azure">
+      <param name="ContainerName" value="testloggingblob"/>
+      <param name="DirectoryName" value="logs"/>
+      <!-- You can either specify a connection string or use the ConnectionStringName property instead -->
+      <param name="ConnectionString" value="UseDevelopmentStorage=true"/>
+      <!--<param name="ConnectionStringName" value="GlobalConfigurationString" />-->
+    </appender>
+	
+* <b>ContainerName:</b>
+  Name of the container in Blob Storage	
+* <b>DirectoryName:</b>
+  Name of the folder in the specified container
+* <b>ConnectionString:</b>
+  the full Azure Storage connection string
+* <b>ConnectionStringName:</b>
+  Name of a connection string specified under connectionString
+
+## View Logs
+
+You can take a look on this [Site](http://storagetools.azurewebsites.net/) to use one of this tools based on your selected appender.

--- a/log4net.Azure.Tests/app.config
+++ b/log4net.Azure.Tests/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/log4net.Azure.Tests/log4net.Azure.Tests.csproj
+++ b/log4net.Azure.Tests/log4net.Azure.Tests.csproj
@@ -43,6 +43,10 @@
     <Reference Include="log4net">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
@@ -58,13 +62,13 @@
     <Reference Include="Microsoft.WindowsAzure.Configuration">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/log4net.Azure.Tests/log4net.Azure.Tests.csproj
+++ b/log4net.Azure.Tests/log4net.Azure.Tests.csproj
@@ -101,10 +101,6 @@
       <Name>log4net.Appender.Azure</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config" />
-  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/log4net.Azure.Tests/packages.config
+++ b/log4net.Azure.Tests/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="5.0.0" targetFramework="net45" />
 </packages>

--- a/log4net.Azure.console/App.config
+++ b/log4net.Azure.console/App.config
@@ -6,17 +6,17 @@
   <log4net>
     <!-- Azure Table Appender, uncomment, set proper QueueName and AWS credentials (appSettings) to try it out -->
     <appender name="AzureAppender1" type="log4net.Appender.AzureTableAppender, log4net.Appender.Azure">
-      <param name="TableName" value="testLoggingTable"/>
+      <param name="TableName" value="testLoggingTable" />
       <!-- You can either specify a connection string or use the ConnectionStringName property instead -->
-      <param name="ConnectionString" value="UseDevelopmentStorage=true"/>
+      <param name="ConnectionString" value="UseDevelopmentStorage=true" />
       <!--<param name="ConnectionStringName" value="GlobalConfigurationString" />-->
     </appender>
     <!-- Azure Blob Appender, uncomment, set proper BucketName and AWS credentials (appSettings) to try it out -->
     <appender name="AzureAppender2" type="log4net.Appender.AzureBlobAppender, log4net.Appender.Azure">
-      <param name="ContainerName" value="testloggingblob"/>
-      <param name="DirectoryName" value="logs"/>
+      <param name="ContainerName" value="testloggingblob" />
+      <param name="DirectoryName" value="logs" />
       <!-- You can either specify a connection string or use the ConnectionStringName property instead -->
-      <param name="ConnectionString" value="UseDevelopmentStorage=true"/>
+      <param name="ConnectionString" value="UseDevelopmentStorage=true" />
       <!--<param name="ConnectionStringName" value="GlobalConfigurationString" />-->
     </appender>
     <appender name="AzureAppender3" type="log4net.Appender.AzureTableAppender, log4net.Appender.Azure">
@@ -42,7 +42,7 @@
   </log4net>
   <connectionStrings>
     <!-- Provided as an example for specifying a global connection string for multiple appenders -->
-    <add name="GlobalConfigurationString" connectionString="UseDevelopmentStorage=true"/>
+    <add name="GlobalConfigurationString" connectionString="UseDevelopmentStorage=true" />
   </connectionStrings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
@@ -63,7 +63,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/log4net.Azure.console/App.config
+++ b/log4net.Azure.console/App.config
@@ -10,9 +10,6 @@
       <!-- You can either specify a connection string or use the ConnectionStringName property instead -->
       <param name="ConnectionString" value="UseDevelopmentStorage=true"/>
       <!--<param name="ConnectionStringName" value="GlobalConfigurationString" />-->
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
-      </layout>
     </appender>
     <!-- Azure Blob Appender, uncomment, set proper BucketName and AWS credentials (appSettings) to try it out -->
     <appender name="AzureAppender2" type="log4net.Appender.AzureBlobAppender, log4net.Appender.Azure">
@@ -21,19 +18,14 @@
       <!-- You can either specify a connection string or use the ConnectionStringName property instead -->
       <param name="ConnectionString" value="UseDevelopmentStorage=true"/>
       <!--<param name="ConnectionStringName" value="GlobalConfigurationString" />-->
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
-      </layout>
     </appender>
     <appender name="AzureAppender3" type="log4net.Appender.AzureTableAppender, log4net.Appender.Azure">
       <param name="TableName" value="testDynamicLoggingTable" />
       <!-- You can either specify a connection string or use the ConnectionStringName property instead -->
       <param name="ConnectionString" value="UseDevelopmentStorage=true" />
       <!--<param name="ConnectionStringName" value="GlobalConfigurationString" />-->
+      <!-- You can either specify to make each LogProperty as separate Column in TableStorage -->
       <param name="PropAsColumn" value="true" />
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
-      </layout>
     </appender>
     <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
       <layout type="log4net.Layout.PatternLayout">

--- a/log4net.Azure/app.config
+++ b/log4net.Azure/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/log4net.Azure/log4net.Appender.Azure.csproj
+++ b/log4net.Azure/log4net.Appender.Azure.csproj
@@ -38,6 +38,10 @@
     <Reference Include="log4net">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
@@ -58,13 +62,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.5.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/log4net.Azure/packages.config
+++ b/log4net.Azure/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="5.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hi Karell,

I have updated the Readme file to use this as a small configuration documentation. In Preparation for a change we have discussed (How to Order in Table Storage #8) as option.

In the Configuration there where the following lines:

    <layout type="log4net.Layout.PatternLayout">
      <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
    </layout>

I think this is not used or am I wrong?

Regards
Erik