### PR TITLE
Allow to log items to Azure Table by using layout if available.

### DIFF
--- a/log4net.Azure/AzureLayoutLoggingEventEntity.cs
+++ b/log4net.Azure/AzureLayoutLoggingEventEntity.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Microsoft.WindowsAzure.Storage.Table;
+using log4net.Core;
+using log4net.Layout;
+
+namespace log4net.Appender
+{
+    internal sealed class AzureLayoutLoggingEventEntity : TableEntity
+    {
+        public AzureLayoutLoggingEventEntity(LoggingEvent e, PartitionKeyTypeEnum partitionKeyType, ILayout layout)
+        {
+            Level = e.Level.ToString();
+            Message = e.RenderedMessage + Environment.NewLine + e.GetExceptionString();
+            ThreadName = e.ThreadName;
+            EventTimeStamp = e.TimeStamp;
+            using (var w = new StringWriter())
+            {
+                layout.Format(w, e);
+                Message = w.ToString();
+            }
+
+            PartitionKey = e.MakePartitionKey(partitionKeyType);
+            RowKey = e.MakeRowKey();
+        }
+
+        public DateTime EventTimeStamp { get; set; }
+
+        public string ThreadName { get; set; }
+
+        public string Level { get; set; }
+
+        public string Message { get; set; }
+    }
+}

--- a/log4net.Azure/AzureTableAppender.cs
+++ b/log4net.Azure/AzureTableAppender.cs
@@ -89,6 +89,11 @@ namespace log4net.Appender
 
         private ITableEntity GetLogEntity(LoggingEvent @event)
         {
+            if (Layout != null)
+            {
+                return new AzureLayoutLoggingEventEntity(@event, PartitionKeyType, Layout);
+            }
+
             return PropAsColumn
                 ? (ITableEntity)new AzureDynamicLoggingEventEntity(@event, PartitionKeyType)
                 : new AzureLoggingEventEntity(@event, PartitionKeyType);

--- a/log4net.Azure/log4net.Appender.Azure.csproj
+++ b/log4net.Azure/log4net.Appender.Azure.csproj
@@ -83,6 +83,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AzureDynamicLoggingEventEntity.cs" />
+    <Compile Include="AzureLayoutLoggingEventEntity.cs" />
     <Compile Include="AzureLoggingEventEntity.cs" />
     <Compile Include="AzureTableAppender.cs" />
     <Compile Include="AzureBlobAppender.cs" />


### PR DESCRIPTION
It allows the use of custom layout. E.g.:
```xml
<appender name="AzureTableAppender" type="log4net.Appender.AzureTableAppender,log4net.Appender.Azure">
      .....
      <layout type="log4net.Layout.PatternLayout">
        <conversionPattern value="%method -- %message %exception" />
      </layout>
</appender>
```