### PR TITLE
Proposal: Async table appender w/ message splitting 

### DIFF
--- a/log4net.Azure.Tests/UnitTestAsyncAzureTableAppender.cs
+++ b/log4net.Azure.Tests/UnitTestAsyncAzureTableAppender.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using log4net.Appender;
+using log4net.Core;
+
+namespace log4net.Azure.Tests
+{
+    [TestClass]
+    public class UnitTestAsyncAzureTableAppender
+    {
+        private AsyncAzureTableAppender _appender;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _appender = new AsyncAzureTableAppender()
+                {
+                    ConnectionString = "UseDevelopmentStorage=true",
+                    TableName = "testLoggingTable"
+                };
+            _appender.ActivateOptions();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _appender.Close();
+        }
+
+        [TestMethod]
+        public void Test_Table_Appender()
+        {
+            var @event = MakeEvent();
+
+            _appender.DoAppend(@event);
+        }
+
+        [TestMethod]
+        public void Test_Message_With_Exception()
+        {
+            const string message = "Exception to follow on other line";
+            var ex = new Exception("This is the exception message");
+
+            var @event = new LoggingEvent(null, null, "testLoggerName", Level.Critical, message, ex);
+
+            _appender.DoAppend(@event);
+        }
+
+        [TestMethod]
+        public void Test_Table_Appender_Multiple_5()
+        {
+            _appender.DoAppend(MakeEvents(5));
+        }
+
+        [TestMethod]
+        public void Test_Table_Appender_Multiple_10()
+        {
+            _appender.DoAppend(MakeEvents(10));
+        }
+
+        [TestMethod]
+        public void Test_Table_Appender_Multiple_100()
+        {
+            _appender.DoAppend(MakeEvents(100));
+        }
+
+        private static LoggingEvent[] MakeEvents(int number)
+        {
+            var result = new LoggingEvent[number];
+            for (int i = 0; i < number; i++)
+            {
+                result[i] = MakeEvent();
+            }
+            return result;
+        }
+
+        private static LoggingEvent MakeEvent()
+        {
+            return new LoggingEvent(
+                new LoggingEventData
+                    {
+                        Domain = "testDomain",
+                        Identity = "testIdentity",
+                        Level = Level.Critical,
+                        LoggerName = "testLoggerName",
+                        Message = "testMessage",
+                        ThreadName = "testThreadName",
+                        TimeStamp = DateTime.UtcNow,
+                        UserName = "testUsername",
+                        LocationInfo = new LocationInfo("className", "methodName", "fileName", "lineNumber")
+                    }
+                );
+        }
+    }
+}

--- a/log4net.Azure.Tests/UnitTestAsyncAzureTableAppender.cs
+++ b/log4net.Azure.Tests/UnitTestAsyncAzureTableAppender.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using log4net.Appender;
 using log4net.Core;
@@ -31,6 +32,26 @@ namespace log4net.Azure.Tests
         public void Test_Table_Appender()
         {
             var @event = MakeEvent();
+
+            _appender.DoAppend(@event);
+        }
+
+        [TestMethod]
+        public void Test_GiantMessage()
+        {
+            var @event = new LoggingEvent(
+                new LoggingEventData
+                {
+                    Domain = "testDomain",
+                    Identity = "testIdentity",
+                    Level = Level.Critical,
+                    LoggerName = "testLoggerName",
+                    Message = "Long message - " + string.Join("-", Enumerable.Range(0,1024).Select(i => "QWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm")),
+                    ThreadName = "testThreadName",
+                    TimeStamp = DateTime.UtcNow,
+                    UserName = "testUsername",
+                    LocationInfo = new LocationInfo("className", "methodName", "fileName", "lineNumber")
+                });
 
             _appender.DoAppend(@event);
         }

--- a/log4net.Azure.Tests/log4net.Azure.Tests.csproj
+++ b/log4net.Azure.Tests/log4net.Azure.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="UnitTestAzureBlobAppender.cs" />
     <Compile Include="UnitTestAzureDynamicTableAppender.cs" />
     <Compile Include="UnitTestAzureQueueAppender.cs" />
+    <Compile Include="UnitTestAsyncAzureTableAppender.cs" />
     <Compile Include="UnitTestAzureTableAppender.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/log4net.Azure/AsyncAzureTableAppender.cs
+++ b/log4net.Azure/AsyncAzureTableAppender.cs
@@ -1,0 +1,127 @@
+using log4net.Appender.Extensions;
+using log4net.Core;
+using Microsoft.WindowsAzure.Storage.Table;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using log4net.Util;
+
+namespace log4net.Appender
+{
+    public class AsyncAzureTableAppender : AzureTableAppender
+    {
+        // track the tasks currently sending data so we can wait for them when we close down
+        private readonly List<Task> _outstandingTasks = new List<Task>();
+
+        // used to calculate the retry interval
+        private readonly Random _rnd = new Random();
+
+        // auto-flush timer
+        private Timer _autoFlushTimer;
+
+        public int BatchSize { get; set; } = 100;
+        public int RetryCount { get; set; } = 5;
+        public TimeSpan RetryWait { get; set; } = new TimeSpan(0, 0, 5);
+        public TimeSpan FlushInterval { get; set; } = new TimeSpan(0, 1, 0);
+
+        protected override void SendBuffer(LoggingEvent[] events)
+        {
+            // build chunks of no more than 100 each of which share the same partition key
+            var chunks = events.Select(GetLogEntity).GroupBy(e => e.PartitionKey).SelectMany(i => i.Batch(100)).ToList();
+            var tasks = chunks.Select(chunk => Task.Run(async () => await Send(chunk))).ToList();
+
+            // remember the tasks
+            lock (_outstandingTasks)
+            {
+                _outstandingTasks.AddRange(tasks);
+            }
+
+            // remove from the list when complete
+            tasks.ForEach(t => t.ContinueWith(_ =>
+            {
+                lock (_outstandingTasks)
+                {
+                    _outstandingTasks.Remove(t);
+                }
+            }));
+        }
+
+        private async Task Send(IEnumerable<ITableEntity> chunk)
+        {
+            var batchOperation = new TableBatchOperation();
+            foreach (var azureLoggingEvent in chunk)
+            {
+                batchOperation.Insert(azureLoggingEvent);
+            }
+
+            var attempt = 0;
+            while (true)
+            {
+                try
+                {
+                    var sw = System.Diagnostics.Stopwatch.StartNew();
+                    await Table.ExecuteBatchAsync(batchOperation);
+                    LogLog.Debug(typeof(AsyncAzureTableAppender), string.Format("Sent batch of {0} in {1}", batchOperation.Count, sw.Elapsed));
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    attempt++;
+                    if (attempt >= RetryCount)
+                    {
+                        LogLog.Error(typeof(AsyncAzureTableAppender), string.Format("Exception sending batch, aborting: {0}", ex.Message));
+                        return;
+                    }
+
+                    LogLog.Warn(typeof(AsyncAzureTableAppender), string.Format("Exception sending batch, retrying: {0}", ex.Message));
+
+                    // wait for a bit longer each time, and add a bit of randomness to make sure we're not retrying in lockstep
+                    var wait = TimeSpan.FromSeconds(RetryWait.TotalSeconds * (attempt + GetExtraWaitModifier()));
+                    await Task.Delay(wait);
+                }
+            }
+        }
+
+        private double GetExtraWaitModifier()
+        {
+            lock (_rnd)
+            {
+                return _rnd.NextDouble();
+            }
+        }
+
+        public override void ActivateOptions()
+        {
+            base.ActivateOptions();
+
+            _autoFlushTimer = new Timer(s =>
+            {
+                LogLog.Debug(typeof(AsyncAzureTableAppender), "Triggering flush");
+                this.Flush(false);
+            }, null, TimeSpan.FromSeconds(0), FlushInterval);
+        }
+
+        protected override void OnClose()
+        {
+            LogLog.Debug(typeof(AsyncAzureTableAppender), "Closing");
+            if (null != _autoFlushTimer)
+            {
+                _autoFlushTimer.Dispose();
+                _autoFlushTimer = null;
+            }
+            base.OnClose();
+
+            // the close would have triggered a flush, which would have created messages in the queue.  Wait until they're all done.
+            Task[] tasks;
+            lock (_outstandingTasks)
+            {
+                tasks = _outstandingTasks.ToArray();
+            }
+            LogLog.Debug(typeof(AsyncAzureTableAppender), string.Format("Waiting on {0} outstanding logging calls", tasks.Length));
+            Task.WaitAll(tasks);
+            LogLog.Debug(typeof(AsyncAzureTableAppender), "Completing close");
+        }
+    }
+}

--- a/log4net.Azure/AzureDynamicLoggingEventEntity.cs
+++ b/log4net.Azure/AzureDynamicLoggingEventEntity.cs
@@ -36,5 +36,11 @@ namespace log4net.Appender
             PartitionKey = e.MakePartitionKey(partitionKeyType);
             RowKey = e.MakeRowKey();
         }
+
+        public AzureDynamicLoggingEventEntity(LoggingEvent e, PartitionKeyTypeEnum partitionKeyType, string message, int sequenceNumber) : this(e, partitionKeyType)
+        {
+            this["Message"] = message;
+            this["SequenceNumber"] = sequenceNumber;
+        }
     }
 }

--- a/log4net.Azure/AzureLayoutLoggingEventEntity.cs
+++ b/log4net.Azure/AzureLayoutLoggingEventEntity.cs
@@ -22,6 +22,13 @@ namespace log4net.Appender
 
             PartitionKey = e.MakePartitionKey(partitionKeyType);
             RowKey = e.MakeRowKey();
+            SequenceNumber = 0;
+        }
+
+        public AzureLayoutLoggingEventEntity(LoggingEvent e, PartitionKeyTypeEnum partitionKeyType, ILayout layout, string message, int sequenceNumber) : this(e, partitionKeyType, layout)
+        {
+            Message = message;
+            SequenceNumber = sequenceNumber;
         }
 
         public DateTime EventTimeStamp { get; set; }
@@ -31,5 +38,7 @@ namespace log4net.Appender
         public string Level { get; set; }
 
         public string Message { get; set; }
+
+        public int SequenceNumber { get; set; }
     }
 }

--- a/log4net.Azure/AzureLoggingEventEntity.cs
+++ b/log4net.Azure/AzureLoggingEventEntity.cs
@@ -38,6 +38,13 @@ namespace log4net.Appender
 
             PartitionKey = e.MakePartitionKey(partitionKeyType);
             RowKey = e.MakeRowKey();
+            SequenceNumber = 0;
+        }
+
+        public AzureLoggingEventEntity(LoggingEvent e, PartitionKeyTypeEnum partitionKeyType, string message, int sequenceNumber) : this(e, partitionKeyType)
+        {
+            Message = message;
+            SequenceNumber = sequenceNumber;
         }
 
         public string UserName { get; set; }
@@ -69,5 +76,7 @@ namespace log4net.Appender
         public string MethodName { get; set; }
 
         public StackFrameItem[] StackFrames { get; set; }
+
+        public int SequenceNumber { get; set; }
     }
 }

--- a/log4net.Azure/AzureTableAppender.cs
+++ b/log4net.Azure/AzureTableAppender.cs
@@ -64,14 +64,14 @@ namespace log4net.Appender
 
         protected override void SendBuffer(LoggingEvent[] events)
         {
-            var grouped = events.GroupBy(evt => evt.LoggerName);
+            var grouped = events.Select(GetLogEntity).GroupBy(evt => evt.PartitionKey);
 
             foreach (var group in grouped)
             {
                 foreach (var batch in group.Batch(100))
                 {
                     var batchOperation = new TableBatchOperation();
-                    foreach (var azureLoggingEvent in batch.Select(GetLogEntity))
+                    foreach (var azureLoggingEvent in batch)
                     {
                         batchOperation.Insert(azureLoggingEvent);
                     }

--- a/log4net.Azure/AzureTableAppender.cs
+++ b/log4net.Azure/AzureTableAppender.cs
@@ -53,6 +53,8 @@ namespace log4net.Appender
             }
         }
 
+        protected CloudTable Table {  get { return _table; } }
+
         public bool PropAsColumn { get; set; }
 
 	    private PartitionKeyTypeEnum _partitionKeyType = PartitionKeyTypeEnum.LoggerName;
@@ -80,7 +82,7 @@ namespace log4net.Appender
             }
         }
 
-        private ITableEntity GetLogEntity(LoggingEvent @event)
+        protected ITableEntity GetLogEntity(LoggingEvent @event)
         {
             if (Layout != null)
             {

--- a/log4net.Azure/log4net.Appender.Azure.csproj
+++ b/log4net.Azure/log4net.Appender.Azure.csproj
@@ -88,6 +88,7 @@
     <Compile Include="AzureLayoutLoggingEventEntity.cs" />
     <Compile Include="AzureLoggingEventEntity.cs" />
     <Compile Include="AzureQueueAppender.cs" />
+    <Compile Include="AsyncAzureTableAppender.cs" />
     <Compile Include="AzureTableAppender.cs" />
     <Compile Include="AzureBlobAppender.cs" />
     <Compile Include="ElasticTableEntity.cs" />


### PR DESCRIPTION
(includes everything from #54) 

In addition to #54, my team also wanted to support messages larger than the 16k limit for entities, so we added some more code to split the message (repeating the rest of the data) for long entities.

This is a bit more aggressive, so I'm submitting it as a separate PR in case you want #54 and not this.